### PR TITLE
Bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cbf1fe0034533c53c5c41761017065f85207a1b770483e98b2392315f6575e87
 
 build:
-  number: 0
+  number: 1
   skip: true        # [win]
 
 requirements:


### PR DESCRIPTION
This is needed after conda-forge/libflint-feedstock#3